### PR TITLE
feat: Smart video matching for match cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,12 +19,38 @@ export default function Home() {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [matches, setMatches] = useState<Match[]>([])
   const [hasLiveStream, setHasLiveStream] = useState(false)
+  const [selectedMatchNumber, setSelectedMatchNumber] = useState<number | null>(null)
+  const [selectedMatchDetails, setSelectedMatchDetails] = useState<{
+    teamA?: string
+    teamB?: string
+    venue?: string
+  }>({})
 
   const tabs = ['matches', 'stream', 'groups', 'bracket', 'social', 'input'] as const
   const currentIndex = tabs.indexOf(activeTab as any)
 
   useEffect(() => {
     loadMatches()
+    
+    // Check URL parameters on load
+    const urlParams = new URLSearchParams(window.location.search)
+    const tabParam = urlParams.get('tab')
+    const matchParam = urlParams.get('match')
+    const teamA = urlParams.get('teamA')
+    const teamB = urlParams.get('teamB')
+    const venue = urlParams.get('venue')
+    
+    if (tabParam === 'stream') {
+      setActiveTab('stream')
+      if (matchParam) {
+        setSelectedMatchNumber(parseInt(matchParam))
+        setSelectedMatchDetails({
+          teamA: teamA || undefined,
+          teamB: teamB || undefined,
+          venue: venue || undefined
+        })
+      }
+    }
   }, [])
 
   async function loadMatches() {
@@ -183,7 +209,7 @@ export default function Home() {
         <PullToRefresh onRefresh={handleRefresh}>
           <div className="max-w-7xl mx-auto" {...handlers}>
             {activeTab === 'matches' && <MatchList />}
-            {activeTab === 'stream' && <StreamView onLiveStatusChange={setHasLiveStream} />}
+            {activeTab === 'stream' && <StreamView onLiveStatusChange={setHasLiveStream} selectedMatchNumber={selectedMatchNumber} selectedMatchDetails={selectedMatchDetails} />}
             {activeTab === 'groups' && <GroupStageView />}
             {activeTab === 'bracket' && <TournamentBracket />}
             {activeTab === 'input' && <ScoreInput />}

--- a/src/components/StreamView.tsx
+++ b/src/components/StreamView.tsx
@@ -5,11 +5,25 @@ import { Tv, Radio, Loader2 } from 'lucide-react'
 
 interface StreamViewProps {
   onLiveStatusChange?: (isLive: boolean) => void
+  selectedMatchNumber?: number | null
+  selectedMatchDetails?: {
+    teamA?: string
+    teamB?: string
+    venue?: string
+  }
 }
 
-export default function StreamView({ onLiveStatusChange }: StreamViewProps) {
+interface VideoData {
+  videoId: string
+  title: string
+  thumbnail: string
+  isLive: boolean
+}
+
+export default function StreamView({ onLiveStatusChange, selectedMatchNumber, selectedMatchDetails }: StreamViewProps) {
   const [loading, setLoading] = useState(true)
   const [liveVideoId, setLiveVideoId] = useState<string | null>(null)
+  const [matchVideo, setMatchVideo] = useState<VideoData | null>(null)
   // YouTube channel: https://www.youtube.com/@OrganizerCBL
   const [channelId] = useState('UCSTjgKoXJT41KMsqKnOTxZQ') // OrganizerCBL channel ID
   
@@ -19,6 +33,12 @@ export default function StreamView({ onLiveStatusChange }: StreamViewProps) {
     const interval = setInterval(checkLiveStream, 60000)
     return () => clearInterval(interval)
   }, [])
+
+  useEffect(() => {
+    if (selectedMatchNumber) {
+      findMatchVideo(selectedMatchNumber)
+    }
+  }, [selectedMatchNumber])
 
   const checkLiveStream = async () => {
     try {
@@ -35,6 +55,99 @@ export default function StreamView({ onLiveStatusChange }: StreamViewProps) {
     } catch (error) {
       console.error('Error checking live stream:', error)
       onLiveStatusChange?.(false)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const findMatchVideo = async (matchNumber: number) => {
+    try {
+      setLoading(true)
+      
+      // First check if it's in live videos
+      const liveResponse = await fetch('https://cbl-coverage-api.zeidalqadri.workers.dev/api/youtube/live')
+      const liveData = await liveResponse.json()
+      
+      // Smart matching for live videos
+      const liveMatch = liveData.live?.find((v: VideoData) => {
+        const titleLower = v.title.toLowerCase()
+        const teamALower = selectedMatchDetails?.teamA?.toLowerCase() || ''
+        const teamBLower = selectedMatchDetails?.teamB?.toLowerCase() || ''
+        const venueLower = selectedMatchDetails?.venue?.toLowerCase() || ''
+        
+        // Match by match number first
+        if (titleLower.includes(`match #${matchNumber}`)) return true
+        
+        // Match by both team names (in any order)
+        if (teamALower && teamBLower) {
+          const hasTeamA = titleLower.includes(teamALower)
+          const hasTeamB = titleLower.includes(teamBLower)
+          if (hasTeamA && hasTeamB) return true
+        }
+        
+        // Match by venue if provided
+        if (venueLower && titleLower.includes(venueLower)) {
+          // Additional check: if venue matches and it's the right time
+          return true
+        }
+        
+        return false
+      })
+      
+      if (liveMatch) {
+        setMatchVideo(liveMatch)
+        return
+      }
+      
+      // Search for recorded matches with multiple strategies
+      const searchQueries = []
+      
+      // Primary: match number
+      searchQueries.push(`Match #${matchNumber}`)
+      
+      // Secondary: team names
+      if (selectedMatchDetails?.teamA && selectedMatchDetails?.teamB) {
+        searchQueries.push(`${selectedMatchDetails.teamA} vs ${selectedMatchDetails.teamB}`)
+        searchQueries.push(`${selectedMatchDetails.teamA} ${selectedMatchDetails.teamB}`)
+      }
+      
+      // Tertiary: venue
+      if (selectedMatchDetails?.venue) {
+        searchQueries.push(`${selectedMatchDetails.venue} Match #${matchNumber}`)
+      }
+      
+      for (const query of searchQueries) {
+        const searchResponse = await fetch(
+          `https://cbl-coverage-api.zeidalqadri.workers.dev/api/youtube/search?q=${encodeURIComponent(query)}`
+        )
+        const searchData = await searchResponse.json()
+        
+        if (searchData.videos?.length > 0) {
+          // Further filter to ensure relevance
+          const relevantVideo = searchData.videos.find((v: VideoData) => {
+            const titleLower = v.title.toLowerCase()
+            const teamALower = selectedMatchDetails?.teamA?.toLowerCase() || ''
+            const teamBLower = selectedMatchDetails?.teamB?.toLowerCase() || ''
+            
+            // Check match number
+            if (titleLower.includes(`match #${matchNumber}`)) return true
+            
+            // Check both team names
+            if (teamALower && teamBLower) {
+              return titleLower.includes(teamALower) && titleLower.includes(teamBLower)
+            }
+            
+            return false
+          })
+          
+          if (relevantVideo) {
+            setMatchVideo(relevantVideo)
+            break
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error finding match video:', error)
     } finally {
       setLoading(false)
     }
@@ -73,28 +186,68 @@ export default function StreamView({ onLiveStatusChange }: StreamViewProps) {
         </div>
       </div>
 
-      {/* Stream Embed */}
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm overflow-hidden">
-        <div className="relative aspect-video bg-black">
-          {liveVideoId ? (
+      {/* Selected Match Video */}
+      {matchVideo && selectedMatchNumber && (
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm overflow-hidden mb-6">
+          <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-lg font-semibold flex items-center gap-2">
+                  Match #{selectedMatchNumber}
+                  {matchVideo.isLive && (
+                    <span className="text-red-500 text-sm font-medium animate-pulse">LIVE</span>
+                  )}
+                </h3>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{matchVideo.title}</p>
+              </div>
+              <button
+                onClick={() => {
+                  const url = new URL(window.location.href);
+                  url.searchParams.delete('match');
+                  window.location.href = url.toString();
+                }}
+                className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                ← Back to all videos
+              </button>
+            </div>
+          </div>
+          <div className="relative aspect-video bg-black">
             <iframe
-              src={`https://www.youtube.com/embed/${liveVideoId}?autoplay=1&mute=1`}
-              title="Everything CBL Live Stream"
+              src={`https://www.youtube.com/embed/${matchVideo.videoId}?autoplay=1`}
+              title={matchVideo.title}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowFullScreen
               className="absolute inset-0 w-full h-full"
             />
-          ) : (
-            <iframe
-              src={`https://www.youtube.com/embed/videoseries?list=UU${channelId.substring(2)}&rel=0&showinfo=1`}
-              title="Everything CBL Channel Videos"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              allowFullScreen
-              className="absolute inset-0 w-full h-full"
-            />
-          )}
+          </div>
         </div>
-      </div>
+      )}
+
+      {/* Stream Embed - Only show when no specific match is selected */}
+      {!matchVideo && (
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm overflow-hidden">
+          <div className="relative aspect-video bg-black">
+            {liveVideoId ? (
+              <iframe
+                src={`https://www.youtube.com/embed/${liveVideoId}?autoplay=1&mute=1`}
+                title="Everything CBL Live Stream"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+                className="absolute inset-0 w-full h-full"
+              />
+            ) : (
+              <iframe
+                src={`https://www.youtube.com/embed/videoseries?list=UU${channelId.substring(2)}&rel=0&showinfo=1`}
+                title="Everything CBL Channel Videos"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+                className="absolute inset-0 w-full h-full"
+              />
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Info Section */}
       <div className="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-gray-800 dark:to-gray-900 rounded-lg p-6">


### PR DESCRIPTION
## Summary
- Enhanced video detection to intelligently match videos to tournament matches
- Videos are now matched by team names in addition to match numbers
- Improved accuracy and flexibility in identifying match recordings

## What's Changed
- **Smart Matching Algorithm**: Videos are matched using multiple criteria:
  - Primary: Match number (e.g., "Match #45")
  - Secondary: Both team names appearing in title (in any order)
  - Tertiary: Venue matching for live streams
  - Fallback: Various search query combinations

- **Enhanced Navigation**: 
  - Match cards with available videos show clickable badges
  - Clicking navigates to Stream tab with the specific match video
  - URL parameters include match number, team names, and venue

- **Stream Tab Improvements**:
  - Displays specific match video when selected from match card
  - Shows "Back to all videos" button for easy navigation
  - Automatically finds and plays the correct video

## Benefits
- Works even when match numbers are missing from video titles
- Handles different team name ordering (Team A vs Team B or Team B vs Team A)
- Supports various video naming conventions
- More reliable video-to-match associations

## Test Plan
1. View match cards and look for video badges (LIVE or Video)
2. Click on a video badge - should navigate to Stream tab
3. Verify the correct match video is displayed
4. Test "Back to all videos" button functionality
5. Test with different URL parameters

🤖 Generated with [Claude Code](https://claude.ai/code)